### PR TITLE
Remove device identifier requirement from FUS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Commands:
 Options:
   -m, --model <MODEL>      The model name (e.g. SM-S931U1)
   -r, --region <REGION>    Region CSC code (e.g. XAA)
-  -i, --imei <IMEI>        IMEI number of the device, or an 8 digit TAC
-  -s, --serial <SERIAL>    Serial number of the device
   -j, --threads <THREADS>  Number of parallel connections [default: 8]
   -h, --help               Print help
   -V, --version            Print version

--- a/src/fusclient.rs
+++ b/src/fusclient.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{DeviceId, auth, imei, xml};
+use crate::{auth, xml};
 use md5::{Digest, Md5};
 use reqwest::blocking::{Client, Response};
 use reqwest::header::{AUTHORIZATION, COOKIE, HeaderMap, HeaderValue, USER_AGENT};
 use std::collections::HashMap;
-use std::time::Duration;
 
 #[derive(Default)]
 pub struct FusClient {
@@ -31,6 +30,7 @@ pub struct FusClient {
 
 #[derive(Default)]
 pub struct BinaryInform {
+    pub version: String,
     pub filename: String,
     pub path: String,
     pub size: u64,
@@ -45,6 +45,7 @@ impl BinaryInform {
         let key = xml::getlogiccheck(&fw_ver, &logic_val);
 
         Some(Self {
+            version: fw_ver,
             filename: kv.remove("BINARY_NAME").unwrap(),
             path: kv.remove("MODEL_PATH").unwrap(),
             size,
@@ -61,47 +62,22 @@ impl FusClient {
         client
     }
 
-    pub fn fetch_binary_info(&mut self, ver: &str, model: &str, region: &str, imei: &DeviceId) {
-        let kv: HashMap<String, String>;
+    pub fn fetch_binary_info(&mut self, model: &str, region: &str) {
+        let req_xml = xml::binary_inform_req_xml(model, region);
 
-        match imei {
-            DeviceId::Imei(s) | DeviceId::Serial(s) => {
-                let req_xml = xml::binary_inform_req_xml(ver, model, region, s, &self.nonce);
+        let xml = self
+            .make_req("NF_DownloadBinaryInform.do", &req_xml)
+            .expect("Info request failed");
 
-                let xml = self
-                    .make_req("NF_DownloadBinaryInform.do", &req_xml)
-                    .expect("Info request failed");
-
-                kv = xml::parse_xml_data(&xml).expect("Info request invalid, maybe invalid IMEI?");
-            }
-            DeviceId::Tac(tac) => loop {
-                let rand_imei = imei::generate_random_imei(tac);
-                let req_xml =
-                    xml::binary_inform_req_xml(ver, model, region, &rand_imei, &self.nonce);
-
-                let xml = self
-                    .make_req("NF_DownloadBinaryInform.do", &req_xml)
-                    .expect("Info request failed");
-
-                match xml::parse_xml_data(&xml) {
-                    None => {
-                        std::thread::sleep(Duration::from_millis(250));
-                    }
-                    Some(data) => {
-                        println!("Generated valid IMEI: {rand_imei}");
-                        kv = data;
-                        break;
-                    }
-                }
-            },
-        }
+        let kv = xml::parse_xml_data(&xml).expect("Info request invalid");
 
         self.info = BinaryInform::new(kv).expect("Info request invalid");
     }
 
     fn make_req(&mut self, path: &str, data: &str) -> Result<String, reqwest::Error> {
         let auth_header_val = format!(
-            "FUS nonce=\"\", signature=\"{}\", nc=\"\", type=\"\", realm=\"\", newauth=\"1\"",
+            "FUS nonce=\"{}\", signature=\"{}\", nc=\"\", type=\"\", realm=\"\", newauth=\"1\"",
+            self.encnonce,
             self.auth
         );
 
@@ -138,8 +114,9 @@ impl FusClient {
             if cookie_str.contains("JSESSIONID") {
                 let parts: Vec<&str> = cookie_str.split(';').collect();
                 for part in parts {
-                    if part.trim().starts_with("JSESSIONID=") {
-                        self.sessid = part.trim().split('=').nth(1).unwrap().to_string();
+                    let part = part.trim();
+                    if part.starts_with("JSESSIONID=") || part.starts_with("JSESSIONID_SVR=") {
+                        self.sessid = part.split('=').nth(1).unwrap().to_string();
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,6 @@
 
 mod auth;
 mod fusclient;
-mod imei;
-mod versionfetch;
 mod xml;
 
 use aes::cipher::inout::InOutBuf;
@@ -44,14 +42,6 @@ struct Cli {
     #[arg(short = 'r', long)]
     region: String,
 
-    /// IMEI number of the device, or an 8 digit TAC
-    #[arg(short = 'i', long)]
-    imei: Option<String>,
-
-    /// Serial number of the device
-    #[arg(short = 's', long)]
-    serial: Option<String>,
-
     /// Number of parallel connections
     #[arg(short = 'j', long, default_value_t = 8)]
     threads: u64,
@@ -73,39 +63,20 @@ enum Commands {
     Check,
 }
 
-pub enum DeviceId {
-    Imei(String),
-    Tac(String),
-    Serial(String),
-}
-
 fn main() {
     let args = Cli::parse();
 
-    let imei = match (args.imei, args.serial) {
-        (Some(imei), _) => {
-            if imei.len() == 8 {
-                DeviceId::Tac(imei)
-            } else {
-                DeviceId::Imei(imei)
-            }
-        }
-        (None, Some(serial)) => DeviceId::Serial(serial),
-        _ => panic!("IMEI or Serial required (use -i or -s)"),
-    };
-
     match args.command {
         Commands::Check => {
-            let ver = versionfetch::getlatestver(&args.model, &args.region);
-            println!("{}", ver);
+            let mut client = fusclient::FusClient::new();
+            client.fetch_binary_info(&args.model, &args.region);
+            println!("{}", client.info.version);
         }
         Commands::Download { out_dir, out_file } => {
-            let version = versionfetch::getlatestver(&args.model, &args.region);
-            println!("Firmware Version: {}", version);
-
             let mut client = fusclient::FusClient::new();
+            client.fetch_binary_info(&args.model, &args.region);
 
-            client.fetch_binary_info(&version, &args.model, &args.region, &imei);
+            println!("Firmware Version: {}", client.info.version);
 
             let default_name = client
                 .info

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -28,55 +28,25 @@ pub fn getlogiccheck(inp: &str, nonce: &str) -> String {
 }
 
 pub fn binary_inform_req_xml(
-    fwv: &str,
     model: &str,
     region: &str,
-    imei: &str,
-    nonce: &str,
 ) -> String {
-    let logic_check = getlogiccheck(fwv, nonce);
-
-    let (mcc, mnc, cc_code) = if region == "EUX" {
-        ("262", "01", "DE")
-    } else if region == "EUY" {
-        ("220", "01", "RS")
-    } else {
-        ("", "", "")
-    };
-
-    let extra_fields = if region == "EUX" || region == "EUY" {
-        format!(
-            "<DEVICE_AID_CODE><Data>{region}</Data></DEVICE_AID_CODE>\
-             <DEVICE_CC_CODE><Data>{cc_code}</Data></DEVICE_CC_CODE>\
-             <MCC_NUM><Data>{mcc}</Data></MCC_NUM>\
-             <MNC_NUM><Data>{mnc}</Data></MNC_NUM>",
-            region = region,
-            cc_code = cc_code,
-            mcc = mcc,
-            mnc = mnc
-        )
-    } else {
-        String::new()
-    };
-
     format!(
         r#"<FUSMsg>
 <FUSHdr><ProtoVer>1.0</ProtoVer></FUSHdr>
 <FUSBody>
     <Put>
-        <ACCESS_MODE><Data>2</Data></ACCESS_MODE>
+        <ACCESS_MODE><Data>5</Data></ACCESS_MODE>
         <BINARY_NATURE><Data>1</Data></BINARY_NATURE>
         <CLIENT_PRODUCT><Data>Smart Switch</Data></CLIENT_PRODUCT>
-        <DEVICE_FW_VERSION><Data>{fwv}</Data></DEVICE_FW_VERSION>
+        <CLIENT_VERSION><Data>5.0.0.0</Data></CLIENT_VERSION>
+        <DEVICE_FW_VERSION><Data>................</Data></DEVICE_FW_VERSION>
         <DEVICE_LOCAL_CODE><Data>{region}</Data></DEVICE_LOCAL_CODE>
+        <DEVICE_AID_CODE><Data>{region}</Data></DEVICE_AID_CODE>
+        <DEVICE_CC_CODE><Data>DE</Data></DEVICE_CC_CODE>
         <DEVICE_MODEL_NAME><Data>{model}</Data></DEVICE_MODEL_NAME>
-        <UPGRADE_VARIABLE><Data>0</Data></UPGRADE_VARIABLE>
-        <OBEX_SUPPORT><Data>0</Data></OBEX_SUPPORT>
-        <DEVICE_IMEI_PUSH><Data>{imei}</Data></DEVICE_IMEI_PUSH>
-        <DEVICE_PLATFORM><Data>Android</Data></DEVICE_PLATFORM>
-        <CLIENT_VERSION><Data>4.3.23123_1</Data></CLIENT_VERSION>
-        <LOGIC_CHECK><Data>{logic_check}</Data></LOGIC_CHECK>
-        {extra_fields}
+        <LOGIC_CHECK><Data>................</Data></LOGIC_CHECK>
+        <DEVICE_INITIALIZE><Data>2</Data></DEVICE_INITIALIZE>
     </Put>
 </FUSBody>
 </FUSMsg>"#


### PR DESCRIPTION
Allows downloading any firmware without IMEI/Serial and Watch firmwares too.