### PR TITLE
Add version selection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,91 @@
 # samloader-rs
 
-Download firmware for Samsung devices from official Samsung servers.
+A Rust tool to download Samsung firmware via the FUS (Firmware Update Server) protocol.
 
-```
-Usage: samloader <COMMAND>
-
-Commands:
-  download      Download the latest firmware
-  check-update  Check the latest version
-  help          Print this message or the help of the given subcommand(s)
-
-Options:
-  -h, --help     Print help
-  -V, --version  Print version
-```
-
-```
-Usage: samloader download [OPTIONS] --model <model> --region <region>
-
-Options:
-  -m, --model <model>        The model name (e.g. SM-S931U1)
-  -r, --region <region>      Region CSC code (e.g. XAA)
-  -j, --threads <threads>    Number of parallel connections [default: 8]
-  -d, --out-dir <out_dir>    Output directory
-  -o, --out-file <out_file>  Output file path
-  -h, --help                 Print help
-```
-
-```
-Usage: samloader check-update --model <model> --region <region>
-
-Options:
-  -m, --model <model>    The model name (e.g. SM-S931U1)
-  -r, --region <region>  Region CSC code (e.g. XAA)
-  -h, --help             Print help
-```
+Fork of [topjohnwu/samloader-rs](https://github.com/topjohnwu/samloader-rs) with support for **downloading a specific firmware version** (not just the latest).
 
 ## Features
 
-- Samsung server throttles the download speed per connection. This tool downloads the firmware with multiple connections (default: 8) to fully utilize your network bandwidth.
-- Decryption happens on-the-fly. There are no separate download and decryption steps.
+- Download the **latest** Samsung firmware for any model/region
+- Download a **specific firmware version** using `--version` / `-v` flag
+- List **all available firmware versions** with `check-update --all` / `-a`
+- Multi-threaded download with configurable parallelism (`-j`)
+- Automatic decryption of encrypted firmware (`*.enc4` → `*.zip`)
+- No IMEI / serial number required
+- Built on top of the official Samsung FUS protocol
 
-## Install
-
-If you have a working Rust toolchain installed, you can simply install with the following command:
+## Installation
 
 ```bash
-cargo install samloader
+cargo install --path .
 ```
 
-You can also download the prebuilt executables for Linux, macOS, and Windows in the [latest GitHub release](https://github.com/topjohnwu/samloader-rs/releases/latest).
+Or build from source:
 
-## Notes
+```bash
+cargo build --release
+./target/release/samloader --help
+```
 
-This project was originally based on the work of [ananjaser1211/samloader](https://github.com/ananjaser1211/samloader).
+## Usage
+
+### Download the latest firmware
+
+```bash
+samloader download -m "SM-S721B" -r "EUX" -d ./firmware
+```
+
+### Download a specific firmware version
+
+```bash
+samloader download -m "SM-S721B" -r "EUX" -v "S721BXXS7BYH1/S721BOXM7BYH1/S721BXXS7BYH1" -d ./firmware
+```
+
+The version string can be in 3-part (PDA/CSC/MODEM) or 4-part (PDA/CSC/MODEM/PDA) format.
+
+### List all available firmware versions
+
+```bash
+samloader check-update -m "SM-S721B" -r "EUX" --all
+```
+
+### Check the latest version only
+
+```bash
+samloader check-update -m "SM-S721B" -r "EUX"
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `-m`, `--model` | Device model (e.g. `SM-S721B`) |
+| `-r`, `--region` | CSC region code (e.g. `EUX`) |
+| `-v`, `--version` | Specific firmware version to download (PDA/CSC/MODEM) |
+| `-j`, `--threads` | Number of parallel connections (default: 8) |
+| `-d`, `--out-dir` | Output directory |
+| `-o`, `--out-file` | Output file path |
+| `-a`, `--all` | List all available versions (check-update only) |
+
+## Patch
+
+This fork adds the following changes on top of upstream v1.2.0:
+
+- `download --version` / `-v`: Download a specific firmware version instead of the latest
+- `check-update --all` / `-a`: List all firmware versions available for a device
+- `fetch_binary_info_for_version()`: New FUS client method for version-specific binary info
+- `fetch_all_versions()`: New FUS client method to enumerate all versions from version.xml
+- `parse_version_xml_all()`: XML parser for all upgrade entries
+- Auto-converts 3-part version strings to 4-part (FUS requirement)
+
+The patch is maintained at `patches/samloader-rs/0001-version-select.patch` in the [ExtremeROM_a14](https://github.com/clangsdorff/ExtremeROM_a14) repo.
+
+## Credits
+
+- [topjohnwu/samloader-rs](https://github.com/topjohnwu/samloader-rs) - Original Rust samloader implementation
+- [nlscc/samloader](https://github.com/nlscc/samloader) - Original Python samloader
+- Samsung FUS protocol
+
+## License
+
+Apache 2.0

--- a/fus/src/fusclient.rs
+++ b/fus/src/fusclient.rs
@@ -73,6 +73,39 @@ impl FusClient {
         self.info = BinaryInform::parse(&xml).expect("Info request invalid");
     }
 
+    pub fn fetch_binary_info_for_version(&mut self, model: &str, region: &str, version: &str) {
+        let mut parts: Vec<&str> = version.split('/').collect();
+        if parts.len() == 3 {
+            parts.push(parts[0]);
+        }
+        let fw = parts.join("/");
+        let req_xml = xml::binary_inform_req_xml(model, region, &fw, &self.nonce);
+
+        let xml = self
+            .make_req("NF_SmartDownloadBinaryInform.do", &req_xml)
+            .and_then(Response::text)
+            .expect("Info request failed");
+
+        self.info = BinaryInform::parse(&xml).expect("Info request invalid");
+    }
+
+    pub fn fetch_all_versions(&self, model: &str, region: &str) -> Vec<String> {
+        let version_url = format!(
+            "https://fota-cloud-dn.ospserver.net:443/firmware/{}/{}/version.xml",
+            region, model
+        );
+        let version_xml = self
+            .client
+            .get(&version_url)
+            .header(USER_AGENT, "Kies2.0_FUS")
+            .send()
+            .expect("Failed to fetch version.xml")
+            .text()
+            .expect("Failed to read version.xml text");
+
+        xml::parse_version_xml_all(&version_xml)
+    }
+
     fn make_headers(&self) -> HeaderMap {
         let auth_val = format!(
             "FUS nonce=\"{}\", signature=\"{}\", nc=\"\", type=\"\", realm=\"\", newauth=\"1\"",

--- a/fus/src/xml.rs
+++ b/fus/src/xml.rs
@@ -45,6 +45,54 @@ pub(crate) fn parse_version_xml(xml: &str) -> Option<String> {
     Some(parts.join("/"))
 }
 
+pub(crate) fn parse_version_xml_all(xml: &str) -> Vec<String> {
+    let doc = Document::parse(xml).ok();
+    if doc.is_none() {
+        return Vec::new();
+    }
+    let doc = doc.unwrap();
+
+    let mut versions: Vec<String> = Vec::new();
+
+    for value_node in doc.descendants().filter(|n| n.has_tag_name("value")) {
+        if let Some(text) = value_node.text() {
+            let trimmed = text.trim();
+            if !trimmed.is_empty() {
+                let mut parts: Vec<&str> = trimmed.split("/").collect();
+                if parts.len() == 3 {
+                    parts.push(parts[0]);
+                }
+                if parts.len() >= 3 && parts[2].is_empty() {
+                    parts[2] = parts[0];
+                }
+                versions.push(parts.join("/"));
+            }
+        }
+    }
+
+    if let Some(latest) = doc.descendants()
+        .find(|n| n.has_tag_name("latest"))
+        .and_then(|n| n.text())
+    {
+        let trimmed = latest.trim();
+        if !trimmed.is_empty() {
+            let mut parts: Vec<&str> = trimmed.split("/").collect();
+            if parts.len() == 3 {
+                parts.push(parts[0]);
+            }
+            if parts.len() >= 3 && parts[2].is_empty() {
+                parts[2] = parts[0];
+            }
+            versions.push(parts.join("/"));
+        }
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    versions.retain(|v| seen.insert(v.clone()));
+
+    versions
+}
+
 pub(crate) fn binary_inform_req_xml(model: &str, region: &str, fw: &str, nonce: &str) -> String {
     let logic_check = get_logic_check(fw, nonce);
 

--- a/samloader/src/download.rs
+++ b/samloader/src/download.rs
@@ -32,6 +32,9 @@ pub(crate) struct DownloadArgs {
     /// Region CSC code (e.g. XAA)
     pub(crate) region: String,
 
+    /// Optional: firmware version. If None, downloads the latest.
+    pub(crate) version: Option<String>,
+
     /// Number of parallel connections
     pub(crate) threads: u64,
 
@@ -44,7 +47,15 @@ pub(crate) struct DownloadArgs {
 
 pub(crate) fn download_latest_firmware(args: DownloadArgs) {
     let mut client = FusClient::new().expect("Unable to establish FusClient");
-    client.fetch_binary_info(&args.model, &args.region);
+
+    match &args.version {
+        Some(version) => {
+            client.fetch_binary_info_for_version(&args.model, &args.region, version);
+        }
+        None => {
+            client.fetch_binary_info(&args.model, &args.region);
+        }
+    }
 
     println!("Firmware Version: {}", client.info.version);
 

--- a/samloader/src/main.rs
+++ b/samloader/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
         .arg_required_else_help(true)
         .subcommand(
             Command::new("download")
-                .about("Download the latest firmware")
+                .about("Download firmware")
                 .arg(
                     Arg::new("model")
                         .short('m')
@@ -40,6 +40,12 @@ fn main() {
                         .long("region")
                         .required(true)
                         .help("Region CSC code (e.g. XAA)"),
+                )
+                .arg(
+                    Arg::new("version")
+                        .short('v')
+                        .long("version")
+                        .help("Firmware version string (e.g. PDA/CSC/MODEM). If omitted, downloads the latest."),
                 )
                 .arg(
                     Arg::new("threads")
@@ -64,7 +70,7 @@ fn main() {
         )
         .subcommand(
             Command::new("check-update")
-                .about("Check the latest version")
+                .about("Check available versions")
                 .arg(
                     Arg::new("model")
                         .short('m')
@@ -78,6 +84,13 @@ fn main() {
                         .long("region")
                         .required(true)
                         .help("Region CSC code (e.g. XAA)"),
+                )
+                .arg(
+                    Arg::new("all")
+                        .short('a')
+                        .long("all")
+                        .help("List all available firmware versions")
+                        .action(clap::ArgAction::SetTrue),
                 ),
         )
         .get_matches();
@@ -86,12 +99,14 @@ fn main() {
         Some(("download", sub_m)) => {
             let model = sub_m.get_one::<String>("model").cloned().unwrap();
             let region = sub_m.get_one::<String>("region").cloned().unwrap();
+            let version = sub_m.get_one::<String>("version").cloned();
             let threads = *sub_m.get_one::<u64>("threads").unwrap();
             let out_dir = sub_m.get_one::<String>("out_dir").cloned();
             let out_file = sub_m.get_one::<String>("out_file").cloned();
             let args = DownloadArgs {
                 model,
                 region,
+                version,
                 threads,
                 out_dir,
                 out_file,
@@ -101,9 +116,19 @@ fn main() {
         Some(("check-update", sub_m)) => {
             let model = sub_m.get_one::<String>("model").cloned().unwrap();
             let region = sub_m.get_one::<String>("region").cloned().unwrap();
+            let show_all = sub_m.get_one::<bool>("all").copied().unwrap_or(false);
+
             let mut client = FusClient::new().expect("Unable to establish FusClient");
-            client.fetch_binary_info(&model, &region);
-            println!("{}", client.info.version);
+
+            if show_all {
+                let versions = client.fetch_all_versions(&model, &region);
+                for v in &versions {
+                    println!("{}", v);
+                }
+            } else {
+                client.fetch_binary_info(&model, &region);
+                println!("{}", client.info.version);
+            }
         }
         _ => unreachable!(),
     };


### PR DESCRIPTION
Features:
- download --version / -v: download a specific firmware version
- check-update --all / -a: list all available firmware versions
- Auto-converts 3-part version strings to 4-part (FUS requirement)

Credits:
- topjohnwu/samloader-rs: upstream base
- nlscc: original Python samloader