### PR TITLE
Accept RESPONSE_TYPE_SEND_FILE_PART for PIT file flash response

### DIFF
--- a/odin/src/odin.rs
+++ b/odin/src/odin.rs
@@ -301,7 +301,9 @@ impl OdinManager {
 
         let response = self.receive_packet::<packets::Response>(3000)?;
 
-        if response.response_type != packets::RESPONSE_TYPE_PIT_FILE {
+        if response.response_type != packets::RESPONSE_TYPE_SEND_FILE_PART
+            && response.response_type != packets::RESPONSE_TYPE_PIT_FILE
+        {
             return Err(OdinError::ResponseTypeMismatch {
                 expected: packets::RESPONSE_TYPE_PIT_FILE,
                 received: response.response_type,


### PR DESCRIPTION
Apparently some devices don't reply with RESPONSE_TYPE_PIT_FILE, but
RESPONSE_TYPE_SEND_FILE_PART.

Fixes: #31