### PR TITLE
fix: fail closed on incomplete firmware data

### DIFF
--- a/fus/src/download.rs
+++ b/fus/src/download.rs
@@ -344,7 +344,12 @@ fn download_chunk(
 
         let stall = loop {
             match resp.read(&mut chunk[dl_pos..]) {
-                Ok(0) => return ChunkOutcome::Done, // chunk fully received and decrypted
+                Ok(0) => {
+                    break std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "download ended before the requested chunk was complete",
+                    );
+                }
                 Ok(n) => dl_pos += n,
                 Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                 Err(e) => break e, // connection dropped: resume the outer loop

--- a/odin/src/error.rs
+++ b/odin/src/error.rs
@@ -179,4 +179,8 @@ pub enum OdinError {
     /// An error occurred while parsing structures or headers.
     #[error("{0}")]
     ParseError(String),
+
+    /// Firmware payload data was truncated or otherwise invalid.
+    #[error("Invalid firmware payload: {0}")]
+    FirmwareDataError(String),
 }

--- a/odin/src/firmware.rs
+++ b/odin/src/firmware.rs
@@ -58,26 +58,33 @@ pub fn verify_md5_footer<R: Read + Seek>(mut reader: R) -> io::Result<()> {
 
     let footer_start = null_idx + 1;
     let footer_bytes = &last_bytes[footer_start..];
-    let footer_str = String::from_utf8_lossy(footer_bytes);
-    let footer_line = footer_str.lines().last().unwrap_or_default();
+    let mut footer_line = footer_bytes
+        .split(|byte| *byte == b'\n')
+        .next()
+        .unwrap_or_default();
+    if footer_line.ends_with(b"\r") {
+        footer_line = &footer_line[..footer_line.len() - 1];
+    }
 
-    if footer_line.len() < 32 {
+    if footer_line.len() != 32 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "Could not find a valid MD5 checksum at the end of the file",
         ));
     }
 
-    let expected_hex = &footer_line[..32];
+    let footer_line = std::str::from_utf8(footer_line)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "MD5 footer is not ASCII"))?;
+
     let mut expected_bytes = [0u8; 16];
     for i in 0..16 {
-        let hex_byte = &expected_hex[i * 2..i * 2 + 2];
+        let hex_byte = &footer_line[i * 2..i * 2 + 2];
         expected_bytes[i] = u8::from_str_radix(hex_byte, 16)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     }
 
-    // The payload size is the exact position up to the MD5 footer text
-    let payload_size = file_size - footer_line.len() as u64 - 1;
+    // The payload ends immediately before the footer, after the TAR null separator.
+    let payload_size = seek_pos + null_idx as u64 + 1;
 
     // Reset file pointer and compute MD5 over the payload only
     reader.seek(SeekFrom::Start(0))?;
@@ -141,6 +148,7 @@ impl Lz4FrameHeader {
 
         let block_independence = ((flg >> 5) & 0x01) == 1;
         let block_checksum = ((flg >> 4) & 0x01) == 1;
+        let content_checksum = ((flg >> 2) & 0x01) == 1;
         let content_size_flag = ((flg >> 3) & 0x01) == 1;
         let dict_id_flag = (flg & 0x01) == 1;
 
@@ -154,6 +162,12 @@ impl Lz4FrameHeader {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "LZ4 block checksum must be disabled",
+            ));
+        }
+        if content_checksum {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "LZ4 content checksum must be disabled",
             ));
         }
         if !block_independence {
@@ -243,6 +257,7 @@ impl<'a> FirmwareLz4File<'a> {
         Lz4DecompressedSequenceIterator {
             decoder: FrameDecoder::new(&self.file[..]),
             sequence_max_bytes,
+            remaining_decompressed: self.header.content_size,
         }
     }
 }
@@ -264,7 +279,7 @@ pub(crate) struct Lz4SequenceIterator<'a> {
 }
 
 impl<'a> Iterator for Lz4SequenceIterator<'a> {
-    type Item = (usize, &'a [u8]);
+    type Item = io::Result<(usize, &'a [u8])>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.finished {
@@ -278,7 +293,10 @@ impl<'a> Iterator for Lz4SequenceIterator<'a> {
         while num_blocks < self.max_blocks {
             if self.bytes_read + 4 > self.file.len() {
                 self.finished = true;
-                break;
+                return Some(Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "LZ4 stream is missing its end mark",
+                )));
             }
             let block_size = u32::from_le_bytes(
                 self.file[self.bytes_read..self.bytes_read + 4]
@@ -289,13 +307,22 @@ impl<'a> Iterator for Lz4SequenceIterator<'a> {
             if block_size == 0 {
                 self.bytes_read += 4; // Advance past EndMark
                 self.finished = true;
+                if self.remaining_decompressed != 0 {
+                    return Some(Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "LZ4 stream ended before the declared content size",
+                    )));
+                }
                 break;
             }
 
             let data_size = (block_size & 0x7FFF_FFFF) as usize;
             if self.bytes_read + 4 + data_size > self.file.len() {
                 self.finished = true;
-                break;
+                return Some(Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "LZ4 block is truncated",
+                )));
             }
 
             self.bytes_read += 4 + data_size;
@@ -313,7 +340,7 @@ impl<'a> Iterator for Lz4SequenceIterator<'a> {
         ) as usize;
         self.remaining_decompressed -= decompressed_size as u64;
 
-        Some((decompressed_size, &self.file[start_pos..end_pos]))
+        Some(Ok((decompressed_size, &self.file[start_pos..end_pos])))
     }
 }
 
@@ -321,28 +348,84 @@ impl<'a> Iterator for Lz4SequenceIterator<'a> {
 pub struct Lz4DecompressedSequenceIterator<'a> {
     decoder: FrameDecoder<&'a [u8]>,
     sequence_max_bytes: usize,
+    remaining_decompressed: u64,
 }
 
 impl<'a> Iterator for Lz4DecompressedSequenceIterator<'a> {
-    type Item = Vec<u8>;
+    type Item = io::Result<Vec<u8>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut buffer = vec![0u8; self.sequence_max_bytes];
-        let mut total_read = 0;
-
-        while total_read < self.sequence_max_bytes {
-            match self.decoder.read(&mut buffer[total_read..]) {
-                Ok(0) => break,
-                Ok(n) => total_read += n,
-                Err(_) => break,
-            }
-        }
-
-        if total_read == 0 {
+        if self.remaining_decompressed == 0 {
             return None;
         }
 
+        let buffer_size =
+            std::cmp::min(self.sequence_max_bytes as u64, self.remaining_decompressed) as usize;
+        let mut buffer = vec![0u8; buffer_size];
+        let mut total_read = 0;
+
+        while total_read < buffer_size {
+            match self.decoder.read(&mut buffer[total_read..]) {
+                Ok(0) => {
+                    return Some(Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "LZ4 stream ended before the declared content size",
+                    )));
+                }
+                Ok(n) => total_read += n,
+                Err(error) => return Some(Err(error)),
+            }
+        }
+
+        self.remaining_decompressed -= total_read as u64;
         buffer.truncate(total_read);
-        Some(buffer)
+        Some(Ok(buffer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn package_with_footer(line_ending: &[u8]) -> Vec<u8> {
+        let mut payload = vec![0xA5; 99];
+        payload.push(0);
+        let mut md5 = Md5::new();
+        md5.update(&payload);
+        let digest = md5.finalize();
+        let checksum = digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        payload.extend_from_slice(checksum.as_bytes());
+        payload.extend_from_slice(line_ending);
+        payload
+    }
+
+    #[test]
+    fn md5_footer_accepts_no_trailing_newline() {
+        assert!(verify_md5_footer(Cursor::new(package_with_footer(b""))).is_ok());
+    }
+
+    #[test]
+    fn md5_footer_accepts_crlf() {
+        assert!(verify_md5_footer(Cursor::new(package_with_footer(b"\r\n"))).is_ok());
+    }
+
+    #[test]
+    fn lz4_content_checksum_is_rejected() {
+        let header = [
+            0x04, 0x22, 0x4D, 0x18, // magic
+            0x6C, // version, independent blocks, content size, content checksum
+            0x60, // 1 MiB blocks
+            0, 0, 0, 0, 0, 0, 0, 0, // content size
+            0, // header checksum (not validated by this parser)
+        ];
+
+        let result = Lz4FrameHeader::parse(Cursor::new(header));
+        assert!(result.is_err());
+        let error = result.err().unwrap();
+        assert!(error.to_string().contains("content checksum"));
     }
 }

--- a/odin/src/odin.rs
+++ b/odin/src/odin.rs
@@ -18,6 +18,7 @@ use crate::packets;
 use crate::packets::{InboundPacket, PitDataPacket, RequestPacket};
 use crate::usb::UsbTransfer;
 use samloader_pit::{BinaryType, PitEntry};
+use std::io;
 use std::time::Duration;
 
 /// A trait for reporting partition flash/upload progress.
@@ -375,14 +376,16 @@ impl OdinManager {
     ) -> Result<(), OdinError>
     where
         Bytes: AsRef<[u8]>,
-        Iter: Iterator<Item = Bytes>,
+        Iter: Iterator<Item = io::Result<Bytes>>,
     {
         let packet = RequestPacket::file_transfer_flash();
         self.request_and_response(&packet, EmptySendKind::After, 3000)
             .map_err(|_| OdinError::FileTransferInitFailed)?;
 
         let mut sequences = sequences.peekable();
-        while let Some(sequence_data) = sequences.next() {
+        while let Some(sequence) = sequences.next() {
+            let sequence_data =
+                sequence.map_err(|error| OdinError::FirmwareDataError(error.to_string()))?;
             let sequence_data = sequence_data.as_ref();
             let start_packet = RequestPacket::flash_part_file_transfer(sequence_data.len() as u32);
 
@@ -413,7 +416,9 @@ impl OdinManager {
         progress: &impl FlashProgress,
     ) -> Result<(), OdinError> {
         progress.set_length(info.file.len() as u64);
-        let sequences = info.sequences(self.file_transfer_sequence_max_bytes());
+        let sequences = info
+            .sequences(self.file_transfer_sequence_max_bytes())
+            .map(Ok);
         self.send_raw_sequences(sequences, info.pit_entry, progress)
     }
 
@@ -439,7 +444,9 @@ impl OdinManager {
         let sequences = info.sequences(self.file_transfer_sequence_max_bytes());
 
         let mut sequences = sequences.peekable();
-        while let Some((decompressed_size, sequence_data)) = sequences.next() {
+        while let Some(sequence) = sequences.next() {
+            let (decompressed_size, sequence_data) =
+                sequence.map_err(|error| OdinError::FirmwareDataError(error.to_string()))?;
             let start_packet =
                 RequestPacket::flash_lz4_part_file_transfer(sequence_data.len() as u32);
 
@@ -478,6 +485,7 @@ impl OdinManager {
             .enumerate()
         {
             let mut success = false;
+            let mut last_mismatch = None;
             for retry in 0..5 {
                 if retry > 0 {
                     println!("\nRetrying...");
@@ -507,11 +515,8 @@ impl OdinManager {
                         if response.value as usize == file_part_index {
                             success = true;
                             break;
-                        } else if retry == 0 {
-                            return Err(OdinError::FilePartIndexMismatch {
-                                expected: file_part_index,
-                                received: response.value,
-                            });
+                        } else {
+                            last_mismatch = Some(response.value);
                         }
                     }
                     _ => {}
@@ -519,6 +524,12 @@ impl OdinManager {
             }
 
             if !success {
+                if let Some(received) = last_mismatch {
+                    return Err(OdinError::FilePartIndexMismatch {
+                        expected: file_part_index,
+                        received,
+                    });
+                }
                 return Err(OdinError::FilePartResponseReceiveFailed);
             }
 

--- a/samloader/src/flash.rs
+++ b/samloader/src/flash.rs
@@ -140,6 +140,10 @@ fn scan_tar_packages(
             let offset = entry.raw_file_position();
             let size = entry.size();
 
+            if !entry.header().entry_type().is_file() || size == 0 {
+                continue;
+            }
+
             let (normalized_name, is_lz4) = normalize_basename(&entry_path);
 
             if normalized_name == "download-list.txt" {
@@ -209,6 +213,10 @@ fn scan_tar_packages(
     for package_entries in all_packages_entries {
         for entry in package_entries {
             if entry.normalized_name.ends_with(".pit") {
+                if pit_entry.is_some() {
+                    print_error!("Multiple PIT files found; refusing to choose one silently.");
+                    return Err(1);
+                }
                 pit_entry = Some(entry);
             } else if let Some(allowlist) = download_allowlist {
                 if allowlist.contains(&entry.normalized_name) {


### PR DESCRIPTION
## Summary

Fixes firmware-integrity and error-handling issues found in the LZ4, FUS download, MD5 footer, TAR scanning, and Odin file-part retry paths.

### Changes

- Propagate LZ4 decoder errors instead of treating them as EOF.
- Reject truncated raw LZ4 blocks and streams missing the EndMark.
- Enforce declared LZ4 content size and reject unsupported content checksums.
- Treat premature downloader EOF as a stalled/incomplete chunk.
- Retry file-part index mismatches and preserve the final mismatch diagnostic.
- Parse MD5 footers using the actual TAR/footer boundary, including no-newline and CRLF forms.
- Return invalid-data errors for malformed non-ASCII MD5 footers instead of risking a UTF-8 slicing panic.
- Skip non-file and zero-length TAR entries before mmap.
- Refuse to silently select among multiple PIT files.

## Verification

- `cargo fmt --all`
- `cargo test -p samloader-odin --no-default-features --features serialport`
- `cargo test -p samloader-fus`
- `cargo check -p samloader --no-default-features --features serialport`

All completed successfully in the available Android-target environment. The default nusb backend cannot be compiled in this environment because its device enumeration API is not enabled for the Android target.
