### PR TITLE
Add GitHub Actions build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # samloader
 
+[![samloader build](https://github.com/topjohnwu/samloader-rs/actions/workflows/build.yml/badge.svg)](https://github.com/topjohnwu/samloader-rs/actions/workflows/build.yml)
+
 An all-in-one Samsung firmware download and flash tool.
 
 ```


### PR DESCRIPTION
The README currently lacks a visible link to the project's release build workflow, making build status harder to discover. This adds a GitHub Actions badge beneath the project title that shows the workflow status and links directly to the workflow details.