### PR TITLE
make samloader-rs compile on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "cfg-if",
  "clap",
  "indicatif",
+ "libc",
  "samloader-fus",
  "samloader-odin",
  "samloader-pit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap = "4.6"
 indicatif = "0.18"
 binrw = "0.15"
 cfg-if = "1.0"
+libc = "0.2"
 modular-bitfield = "0.13.1"
 rusb = { version = "0.9", features = ["vendored"] }
 nusb = "0.2.7"

--- a/samloader/Cargo.toml
+++ b/samloader/Cargo.toml
@@ -16,6 +16,9 @@ clap = { workspace = true }
 indicatif = { workspace = true }
 cfg-if = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+
 [features]
 default = ["nusb", "serialport"]
 rusb = ["samloader-odin/rusb"]


### PR DESCRIPTION
When I run `cargo build` on a linux machine I get:
```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
   --> samloader/src/actions.rs:259:17
    |
259 |     if unsafe { libc::geteuid() != 0 } {
    |                 ^^^^ use of unresolved module or unlinked crate `libc`
    |
    = help: if you wanted to use a crate named `libc`, use `cargo add libc` to add it to your `Cargo.toml`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `samloader` (bin "samloader") due to 1 previous error
```
With this patch it works.

I don't know rust well so take this patch with a grain of salt.